### PR TITLE
Add functional options to make the API cleaner

### DIFF
--- a/acrhelper.go
+++ b/acrhelper.go
@@ -3,51 +3,37 @@ package acrhelper
 import (
 	"context"
 	"fmt"
-	"os"
-	"strings"
-	"time"
 
 	"github.com/docker/docker-credential-helpers/credentials"
 	"github.com/manicminer/hamilton/auth"
-	"github.com/manicminer/hamilton/environments"
 	"github.com/manicminer/hamilton/services/containerregistry"
 )
 
-type config struct {
-	*auth.Config
-	gitHubTokenURL string
-	gitHubToken    string
-	timeout        time.Duration
-}
-
 type ACRHelper struct {
-	cfg              config
-	cachedAuthorizer auth.Authorizer
+	opts       *Options
+	authorizer auth.Authorizer
 }
 
 var _ credentials.Helper = (*ACRHelper)(nil)
 
 // NewACRHelper will return a credentials.Helper that has implemented Get() for Azure Container Registry
-// Parameters:
-// timeout = what the timeout will be for the contexts created when using this helper
-// cacheAuthorizer = should the constructor try to create a cached authorizer
-func NewACRHelper(timeout time.Duration, cacheAuthorizer bool) credentials.Helper {
-	cfg := newConfig(timeout)
+func NewACRHelper(setters ...Option) credentials.Helper {
+	opts := newOptions(setters...)
 
-	var cachedAuthorizer auth.Authorizer
-	if cacheAuthorizer {
-		ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	var authorizer auth.Authorizer
+	if opts.cacheAuthorizerAtConstruction {
+		ctx, cancel := context.WithTimeout(context.Background(), opts.timeout)
 		defer cancel()
 
-		authorizer, err := newCachedAuthorizer(ctx, cfg)
+		a, err := newAuthorizer(ctx, opts)
 		if err == nil {
-			cachedAuthorizer = authorizer
+			authorizer = a
 		}
 	}
 
 	return &ACRHelper{
-		cfg,
-		cachedAuthorizer,
+		opts,
+		authorizer,
 	}
 }
 
@@ -66,20 +52,20 @@ func (ACRHelper) Delete(_ string) error {
 // Get retrieves credentials from the store.
 // It returns username and secret as strings.
 func (acr ACRHelper) Get(serverURL string) (string, string, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), acr.cfg.timeout)
+	ctx, cancel := context.WithTimeout(context.Background(), acr.opts.timeout)
 	defer cancel()
 
-	cachedAuthorizer := acr.cachedAuthorizer
-	if cachedAuthorizer == nil {
-		a, err := newCachedAuthorizer(ctx, acr.cfg)
+	authorizer := acr.authorizer
+	if authorizer == nil {
+		a, err := newAuthorizer(ctx, acr.opts)
 		if err != nil {
 			return "", "", err
 		}
 
-		cachedAuthorizer = a
+		authorizer = a
 	}
 
-	cr := containerregistry.NewContainerRegistryClient(cachedAuthorizer, serverURL, acr.cfg.TenantID)
+	cr := containerregistry.NewContainerRegistryClient(authorizer, serverURL, acr.opts.tenantID)
 	acrToken, _, err := cr.ExchangeRefreshToken(ctx)
 	if err != nil {
 		return "", "", err
@@ -94,92 +80,56 @@ func (acr ACRHelper) List() (map[string]string, error) {
 	return nil, fmt.Errorf("method List() is not implemented")
 }
 
-// newCachedAuthorizer will try to create a cached authorizer based on the config provided
+// newAuthorizer will try to create a cached authorizer based on the config provided
 // 1. Client Certificate
 // 2. Client Secret
 // 3. MSI
 // 4. GitHub OIDC
 // 5. Azure CLI
-func newCachedAuthorizer(ctx context.Context, cfg config) (auth.Authorizer, error) {
-	authorizer, err := auth.NewClientCertificateAuthorizer(ctx, cfg.Environment, cfg.Environment.ResourceManager, cfg.Version, cfg.TenantID, cfg.AuxiliaryTenantIDs, cfg.ClientID, cfg.ClientCertData, cfg.ClientCertPath, cfg.ClientCertPassword)
+func newAuthorizer(ctx context.Context, opts *Options) (auth.Authorizer, error) {
+	authorizer, err := auth.NewClientCertificateAuthorizer(ctx, *opts.environment, opts.environment.ResourceManager, opts.tokenVersion, opts.tenantID, nil, opts.clientID, nil, opts.clientCertPath, opts.clientCertPassword)
 	if err == nil {
-		cachedAuthorizer := auth.NewCachedAuthorizer(authorizer)
-		_, err := cachedAuthorizer.Token()
+		_, err := authorizer.Token()
 		if err == nil {
-			return cachedAuthorizer, nil
+			return authorizer, nil
 		}
 	}
 
-	if cfg.TenantID != "" && cfg.ClientID != "" && cfg.ClientSecret != "" {
-		authorizer, err = auth.NewClientSecretAuthorizer(ctx, cfg.Environment, cfg.Environment.ResourceManager, cfg.Version, cfg.TenantID, cfg.AuxiliaryTenantIDs, cfg.ClientID, cfg.ClientSecret)
+	if opts.tenantID != "" && opts.clientID != "" && opts.clientSecret != "" {
+		authorizer, err = auth.NewClientSecretAuthorizer(ctx, *opts.environment, opts.environment.ResourceManager, opts.tokenVersion, opts.tenantID, nil, opts.clientID, opts.clientSecret)
 		if err == nil {
-			cachedAuthorizer := auth.NewCachedAuthorizer(authorizer)
-			_, err := cachedAuthorizer.Token()
+			_, err := authorizer.Token()
 			if err == nil {
-				return cachedAuthorizer, nil
+				return authorizer, nil
 			}
 		}
 	}
 
-	authorizer, err = auth.NewMsiAuthorizer(ctx, cfg.Environment.ResourceManager, cfg.MsiEndpoint, cfg.ClientID)
+	authorizer, err = auth.NewMsiAuthorizer(ctx, opts.environment.ResourceManager, "", opts.clientID)
 	if err == nil {
-		cachedAuthorizer := auth.NewCachedAuthorizer(authorizer)
-		_, err := cachedAuthorizer.Token()
+		_, err := authorizer.Token()
 		if err == nil {
-			return cachedAuthorizer, nil
+			return authorizer, nil
 		}
 	}
 
-	if cfg.gitHubToken != "" || cfg.gitHubTokenURL != "" {
-		authorizer, err = auth.NewGitHubOIDCAuthorizer(ctx, cfg.Environment, cfg.Environment.ResourceManager, cfg.TenantID, cfg.AuxiliaryTenantIDs, cfg.ClientID, cfg.gitHubTokenURL, cfg.gitHubToken)
+	if opts.gitHubRequestToken != "" || opts.gitHubRequestTokenURL != "" {
+		authorizer, err = auth.NewGitHubOIDCAuthorizer(ctx, *opts.environment, opts.environment.ResourceManager, opts.tenantID, nil, opts.clientID, opts.gitHubRequestTokenURL, opts.gitHubRequestToken)
 		if err == nil {
-			cachedAuthorizer := auth.NewCachedAuthorizer(authorizer)
-			_, err := cachedAuthorizer.Token()
+			_, err := authorizer.Token()
 			if err == nil {
-				return cachedAuthorizer, nil
+				return authorizer, nil
 			}
 		}
 	}
 
-	authorizer, err = auth.NewAzureCliAuthorizer(ctx, cfg.Environment.ResourceManager, cfg.TenantID)
+	authorizer, err = auth.NewAzureCliAuthorizer(ctx, opts.environment.ResourceManager, opts.tenantID)
 	if err == nil {
-		cachedAuthorizer := auth.NewCachedAuthorizer(authorizer)
-		_, err := cachedAuthorizer.Token()
+		_, err := authorizer.Token()
 		if err == nil {
-			return cachedAuthorizer, nil
+			return authorizer, nil
 		}
 	}
 
 	return nil, fmt.Errorf("no valid authorizer could be found")
-}
-
-// newConfig will create a config based on the environment
-// Environment variables read:
-// AZURE_TENANT_ID = Azure tenant ID
-// AZURE_CLIENT_ID = Client ID for the Azure AD application
-// AZURE_CLIENT_SECRET = Client secret for the Azure AD application
-// AZURE_CERTIFICATE_PATH = Path to the certificate
-// AZURE_CERTIFICATE_PASSWORD = Password to the certificate
-// ACTIONS_ID_TOKEN_REQUEST_URL = Provided by GitHub Actions
-// ACTIONS_ID_TOKEN_REQUEST_TOKEN = Provided by GitHub Actions
-func newConfig(timeout time.Duration) config {
-	authCfg := &auth.Config{
-		Environment:        environments.Global,
-		TenantID:           strings.TrimSpace(os.Getenv("AZURE_TENANT_ID")),
-		ClientID:           strings.TrimSpace(os.Getenv("AZURE_CLIENT_ID")),
-		ClientSecret:       strings.TrimSpace(os.Getenv("AZURE_CLIENT_SECRET")),
-		ClientCertPath:     os.Getenv("AZURE_CERTIFICATE_PATH"),
-		ClientCertPassword: os.Getenv("AZURE_CERTIFICATE_PASSWORD"),
-		Version:            auth.TokenVersion2,
-	}
-
-	gitHubTokenURL := strings.TrimSpace(os.Getenv("ACTIONS_ID_TOKEN_REQUEST_URL"))
-	gitHubToken := strings.TrimSpace(os.Getenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN"))
-
-	return config{
-		authCfg,
-		gitHubTokenURL,
-		gitHubToken,
-		timeout,
-	}
 }

--- a/options.go
+++ b/options.go
@@ -1,0 +1,138 @@
+package acrhelper
+
+import (
+	"os"
+	"strings"
+	"time"
+
+	"github.com/manicminer/hamilton/auth"
+	"github.com/manicminer/hamilton/environments"
+)
+
+// Options for the ACRHelper
+type Options struct {
+	environment                   *environments.Environment
+	tokenVersion                  auth.TokenVersion
+	tenantID                      string
+	clientID                      string
+	clientSecret                  string
+	clientCertPath                string
+	clientCertPassword            string
+	gitHubRequestTokenURL         string
+	gitHubRequestToken            string
+	timeout                       time.Duration
+	cacheAuthorizerAtConstruction bool
+}
+
+// Option is a function to set Options
+type Option func(*Options)
+
+func newOptions(setters ...Option) *Options {
+	opts := &Options{
+		environment:                   &environments.Global,
+		tokenVersion:                  auth.TokenVersion2,
+		tenantID:                      strings.TrimSpace(os.Getenv("AZURE_TENANT_ID")),
+		clientID:                      strings.TrimSpace(os.Getenv("AZURE_CLIENT_ID")),
+		clientSecret:                  strings.TrimSpace(os.Getenv("AZURE_CLIENT_SECRET")),
+		clientCertPath:                os.Getenv("AZURE_CERTIFICATE_PATH"),
+		clientCertPassword:            os.Getenv("AZURE_CERTIFICATE_PASSWORD"),
+		gitHubRequestTokenURL:         strings.TrimSpace(os.Getenv("ACTIONS_ID_TOKEN_REQUEST_URL")),
+		gitHubRequestToken:            strings.TrimSpace(os.Getenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN")),
+		timeout:                       10 * time.Second,
+		cacheAuthorizerAtConstruction: true,
+	}
+
+	for _, setter := range setters {
+		setter(opts)
+	}
+
+	return opts
+}
+
+// WithEnvironment will set the Azure environment to use
+// Default: &environments.Global
+func WithEnvironment(opt *environments.Environment) Option {
+	return func(opts *Options) {
+		opts.environment = opt
+	}
+}
+
+// WithTokenVersion will set the Azure AD token version to request
+// Default: auth.TokenVersion2
+func WithTokenVersion(opt auth.TokenVersion) Option {
+	return func(opts *Options) {
+		opts.tokenVersion = opt
+	}
+}
+
+// WithTenantID will set the tenant id to use for requesting Azure AD tokens
+// Default (environment variable): AZURE_TENANT_ID
+func WithTenantID(opt string) Option {
+	return func(opts *Options) {
+		opts.tenantID = opt
+	}
+}
+
+// WithClientID will set the client id to use for requesting Azure AD tokens
+// Default (environment variable): AZURE_CLIENT_ID
+func WithClientID(opt string) Option {
+	return func(opts *Options) {
+		opts.clientID = opt
+	}
+}
+
+// WithClientSecret will set the client secret to use for requesting Azure AD tokens
+// Default (environment variable): AZURE_CLIENT_SECRET
+func WithClientSecret(opt string) Option {
+	return func(opts *Options) {
+		opts.clientSecret = opt
+	}
+}
+
+// WithClientCertPath will set the client certificate path to use for requesting Azure AD tokens
+// Default (environment variable): AZURE_CERTIFICATE_PATH
+func WithClientCertPath(opt string) Option {
+	return func(opts *Options) {
+		opts.clientCertPath = opt
+	}
+}
+
+// WithClientCertPassword will set the client certificate password to use for requesting Azure AD tokens
+// Default (environment variable): AZURE_CERTIFICATE_PASSWORD
+func WithClientCertPassword(opt string) Option {
+	return func(opts *Options) {
+		opts.clientCertPassword = opt
+	}
+}
+
+// WithGitHubRequestTokenURL will set the GitHub request token URL to use for requesting Azure AD tokens
+// Default (environment variable): ACTIONS_ID_TOKEN_REQUEST_URL
+func WithGitHubRequestTokenURL(opt string) Option {
+	return func(opts *Options) {
+		opts.gitHubRequestTokenURL = opt
+	}
+}
+
+// WithGitHubRequestToken will set the GitHub request token to use for requesting Azure AD tokens
+// Default (environment variable): ACTIONS_ID_TOKEN_REQUEST_TOKEN
+func WithGitHubRequestToken(opt string) Option {
+	return func(opts *Options) {
+		opts.gitHubRequestToken = opt
+	}
+}
+
+// WithTimeout will set the timeout for contexts created inside of ACRHelper
+// Default: 10 seconds
+func WithTimeout(opt time.Duration) Option {
+	return func(opts *Options) {
+		opts.timeout = opt
+	}
+}
+
+// WithCacheAuthorizerAtConstruction will, if enabled, try to create an Azure AD authorizer at construction (`NewACRHelper()`)
+// Default: true
+func WithCacheAuthorizerAtConstruction(opt bool) Option {
+	return func(opts *Options) {
+		opts.cacheAuthorizerAtConstruction = opt
+	}
+}

--- a/options_test.go
+++ b/options_test.go
@@ -1,0 +1,89 @@
+package acrhelper
+
+import (
+	"testing"
+	"time"
+
+	"github.com/manicminer/hamilton/auth"
+	"github.com/manicminer/hamilton/environments"
+)
+
+func TestOptions(t *testing.T) {
+	expectedResult := &Options{
+		environment:                   &environments.Canary,
+		tokenVersion:                  auth.TokenVersion1,
+		tenantID:                      "ze-tenant-id",
+		clientID:                      "ze-client-id",
+		clientSecret:                  "ze-client-secret",
+		clientCertPath:                "ze-client-cert-path",
+		clientCertPassword:            "ze-client-cert-password",
+		gitHubRequestTokenURL:         "ze-github-request-token-url",
+		gitHubRequestToken:            "ze-github-request-token",
+		timeout:                       1337 * time.Millisecond,
+		cacheAuthorizerAtConstruction: true,
+	}
+
+	setters := []Option{
+		WithEnvironment(&environments.Canary),
+		WithTokenVersion(auth.TokenVersion1),
+		WithTenantID("ze-tenant-id"),
+		WithClientID("ze-client-id"),
+		WithClientSecret("ze-client-secret"),
+		WithClientCertPath("ze-client-cert-path"),
+		WithClientCertPassword("ze-client-cert-password"),
+		WithGitHubRequestTokenURL("ze-github-request-token-url"),
+		WithGitHubRequestToken("ze-github-request-token"),
+		WithTimeout(1337 * time.Millisecond),
+		WithCacheAuthorizerAtConstruction(true),
+	}
+
+	result := &Options{}
+
+	for _, setter := range setters {
+		setter(result)
+	}
+
+	if expectedResult.environment != result.environment {
+		t.Fatalf("want %v got %v", expectedResult.environment, result.environment)
+	}
+
+	if expectedResult.tokenVersion != result.tokenVersion {
+		t.Fatalf("want %d got %d", expectedResult.tokenVersion, result.tokenVersion)
+	}
+
+	if expectedResult.tenantID != result.tenantID {
+		t.Fatalf("want %q got %q", expectedResult.tenantID, result.tenantID)
+	}
+
+	if expectedResult.clientID != result.clientID {
+		t.Fatalf("want %q got %q", expectedResult.clientID, result.clientID)
+	}
+
+	if expectedResult.clientSecret != result.clientSecret {
+		t.Fatalf("want %q got %q", expectedResult.clientSecret, result.clientSecret)
+	}
+
+	if expectedResult.clientCertPath != result.clientCertPath {
+		t.Fatalf("want %q got %q", expectedResult.clientCertPath, result.clientCertPath)
+	}
+
+	if expectedResult.clientCertPassword != result.clientCertPassword {
+		t.Fatalf("want %q got %q", expectedResult.clientCertPassword, result.clientCertPassword)
+	}
+
+	if expectedResult.gitHubRequestTokenURL != result.gitHubRequestTokenURL {
+		t.Fatalf("want %q got %q", expectedResult.gitHubRequestTokenURL, result.gitHubRequestTokenURL)
+	}
+
+	if expectedResult.gitHubRequestToken != result.gitHubRequestToken {
+		t.Fatalf("want %q got %q", expectedResult.gitHubRequestToken, result.gitHubRequestToken)
+	}
+
+	if expectedResult.timeout != result.timeout {
+		t.Fatalf("want %q got %q", expectedResult.timeout.String(), result.timeout.String())
+	}
+
+	if expectedResult.cacheAuthorizerAtConstruction != result.cacheAuthorizerAtConstruction {
+		t.Fatalf("want %t got %t", expectedResult.cacheAuthorizerAtConstruction, result.cacheAuthorizerAtConstruction)
+	}
+}


### PR DESCRIPTION
This change also removes the usage of NewCachedAuthorizer() since it's
already used in each of the constructors of the authorizers in hamilton.